### PR TITLE
Lu 5843 getting variables

### DIFF
--- a/blk_serverless.yml
+++ b/blk_serverless.yml
@@ -7,12 +7,12 @@ provider:
   package:
     individually: true
   deploymentBucket:
-    name: spp-results-sandbox-serverless
+    name: spp-results-${self:custom.environment}-serverless
 
 custom:
-  accountId: ${env:aws_account_id}
+  environment: ${env:ENVIRONMENT}
 
-  wranglers: ${file(../wranglers.json)}
+  wranglers: ${file(./wranglers.json)}
   ingest: ${self:custom.wranglers.ingest}
   enrichment: ${self:custom.wranglers.enrichment}
   imputation-movements: ${self:custom.wranglers.imputation-movements}
@@ -99,7 +99,7 @@ stepFunctions:
 
           Ingest:
             Next: Enrichment
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.ingest}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.ingest}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -120,7 +120,7 @@ stepFunctions:
 
           Enrichment:
             Next: Imputation Calculate Movements
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.enrichment}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.enrichment}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -145,7 +145,7 @@ stepFunctions:
 
           Imputation Calculate Movements:
             Next: Should Imputation Run
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-movements}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-movements}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -186,7 +186,7 @@ stepFunctions:
 
           Calculate Means:
             Next: Calculate IQRS
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-means}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-means}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -209,7 +209,7 @@ stepFunctions:
 
           Calculate IQRS:
             Next: Calculate Atypicals
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-iqrs}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-iqrs}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -232,7 +232,7 @@ stepFunctions:
 
           Calculate Atypicals:
             Next: Calculate All-GB Region
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-atyps}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-atyps}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -253,7 +253,7 @@ stepFunctions:
 
           Calculate All-GB Region:
             Next: Re-Calculate Means
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.all-gb-region}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.all-gb-region}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -275,7 +275,7 @@ stepFunctions:
 
           Re-Calculate Means:
             Next: Calculate Factors
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-recalc-means}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-recalc-means}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -298,7 +298,7 @@ stepFunctions:
 
           Calculate Factors:
             Next: Apply Factors
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-calc-factors}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-calc-factors}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -324,7 +324,7 @@ stepFunctions:
 
           Apply Factors:
             Next: Aggregation
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-apply-factors}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-apply-factors}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -388,7 +388,7 @@ stepFunctions:
                         run_id.$: $.run_id
                         total_columns.$: $.total_columns[1]
                         sns_topic_arn.$: $.sns_topic_arn
-                    Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
+                    Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
                     End: true
 
               - StartAt: EntRef Count
@@ -411,7 +411,7 @@ stepFunctions:
                         run_id.$: $.run_id
                         total_columns.$: $.total_columns[0]
                         sns_topic_arn.$: $.sns_topic_arn
-                    Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
+                    Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
                     End: true
 
               - StartAt: Calculate Top2
@@ -434,12 +434,12 @@ stepFunctions:
                         top2_column.$: $.top2_column
                         total_columns.$: $.total_columns[1]
                         sns_topic_arn.$: $.sns_topic_arn
-                    Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-top2}"  # yamllint disable-line rule:line-length
+                    Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-top2}"  # yamllint disable-line rule:line-length
                     End: true
 
           Combiner:
             Next: Disclosure
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-combiner}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-combiner}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -463,7 +463,7 @@ stepFunctions:
 
           Disclosure:
             Next: Success
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.disclosure-wrangler}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.disclosure-wrangler}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -496,17 +496,18 @@ stepFunctions:
 
           Success:
             End: true
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.method-return}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.method-return}"  # yamllint disable-line rule:line-length
             InputPath: $
             ResultPath: $.data.lambdaresult
             Type: Task
 
           Failure:
             End: true
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.error-capture}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.error-capture}"  # yamllint disable-line rule:line-length
             InputPath: $
             ResultPath: $.data.lambdaresult
             Type: Task
 
 plugins:
   - serverless-step-functions
+  - serverless-pseudo-parameters

--- a/brk_serverless.yml
+++ b/brk_serverless.yml
@@ -7,10 +7,10 @@ provider:
   package:
     individually: true
   deploymentBucket:
-    name: spp-results-sandbox-serverless
+    name: spp-results-${self:custom.environment}-serverless
 
 custom:
-  accountId: ${env:aws_account_id}
+  environment: ${env:ENVIRONMENT}
 
   wranglers: ${file(../wranglers.json)}
   ingest: ${self:custom.wranglers.ingest}

--- a/brk_serverless.yml
+++ b/brk_serverless.yml
@@ -97,7 +97,7 @@ stepFunctions:
 
           Ingest:
             Next: Enrichment
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.ingest}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.ingest}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -118,7 +118,7 @@ stepFunctions:
 
           Enrichment:
             Next: Imputation Calculate Movements
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.enrichment}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.enrichment}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -143,7 +143,7 @@ stepFunctions:
 
           Imputation Calculate Movements:
             Next: Should Imputation Run
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-movements}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-movements}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -184,7 +184,7 @@ stepFunctions:
 
           Calculate Means:
             Next: Calculate IQRS
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-means}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-means}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -207,7 +207,7 @@ stepFunctions:
 
           Calculate IQRS:
             Next: Calculate Atypicals
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-iqrs}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-iqrs}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -230,7 +230,7 @@ stepFunctions:
 
           Calculate Atypicals:
             Next: Re-Calculate Means
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-atyps}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-atyps}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -251,7 +251,7 @@ stepFunctions:
 
           Re-Calculate Means:
             Next: Calculate Factors
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-recalc-means}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-recalc-means}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -274,7 +274,7 @@ stepFunctions:
 
           Calculate Factors:
             Next: Apply Factors
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-calc-factors}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-calc-factors}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -300,7 +300,7 @@ stepFunctions:
 
           Apply Factors:
             Next: Re-organise Data
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-apply-factors}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-apply-factors}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -330,7 +330,7 @@ stepFunctions:
 
           Re-organise Data:
             Next: Region Aggregation
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-bricks-splitter}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-bricks-splitter}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -388,7 +388,7 @@ stepFunctions:
                         run_id.$: $.run_id
                         total_columns.$: $.total_columns[1]
                         sns_topic_arn.$: $.sns_topic_arn
-                    Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
+                    Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
                     End: true
 
               - StartAt: Region EntRef Count
@@ -411,7 +411,7 @@ stepFunctions:
                         run_id.$: $.run_id
                         total_columns.$: $.total_columns[0]
                         sns_topic_arn.$: $.sns_topic_arn
-                    Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
+                    Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
                     End: true
 
               - StartAt: Region Calculate Top2
@@ -434,12 +434,12 @@ stepFunctions:
                         top2_column.$: $.top2_column
                         total_columns.$: $.total_columns[1]
                         sns_topic_arn.$: $.sns_topic_arn
-                    Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-top2}"  # yamllint disable-line rule:line-length
+                    Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-top2}"  # yamllint disable-line rule:line-length
                     End: true
 
           Region Combiner:
             Next: Region Disclosure
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-combiner}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-combiner}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -463,7 +463,7 @@ stepFunctions:
 
           Region Disclosure:
             Next: Brick Aggregation
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.disclosure-wrangler}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.disclosure-wrangler}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -530,7 +530,7 @@ stepFunctions:
                         run_id.$: $.run_id
                         total_columns.$: $.total_columns[1]
                         sns_topic_arn.$: $.sns_topic_arn
-                    Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
+                    Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
                     End: true
 
               - StartAt: Brick EntRef Count
@@ -553,7 +553,7 @@ stepFunctions:
                         run_id.$: $.run_id
                         total_columns.$: $.total_columns[0]
                         sns_topic_arn.$: $.sns_topic_arn
-                    Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
+                    Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
                     End: true
 
               - StartAt: Brick Calculate Top2
@@ -576,12 +576,12 @@ stepFunctions:
                         top2_column.$: $.top2_column
                         total_columns.$: $.total_columns[1]
                         sns_topic_arn.$: $.sns_topic_arn
-                    Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-top2}"  # yamllint disable-line rule:line-length
+                    Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-top2}"  # yamllint disable-line rule:line-length
                     End: true
 
           Brick Combiner:
             Next: Brick Disclosure
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-combiner}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-combiner}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -605,7 +605,7 @@ stepFunctions:
 
           Brick Disclosure:
             Next: Success
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.disclosure-wrangler}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.disclosure-wrangler}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -638,14 +638,14 @@ stepFunctions:
 
           Success:
             End: true
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.method-return}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.method-return}"  # yamllint disable-line rule:line-length
             InputPath: $
             ResultPath: $.data.lambdaresult
             Type: Task
 
           Failure:
             End: true
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.error-capture}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.error-capture}"  # yamllint disable-line rule:line-length
             InputPath: $
             ResultPath: $.data.lambdaresult
             Type: Task

--- a/brk_serverless.yml
+++ b/brk_serverless.yml
@@ -12,7 +12,7 @@ provider:
 custom:
   environment: ${env:ENVIRONMENT}
 
-  wranglers: ${file(../wranglers.json)}
+  wranglers: ${file(./wranglers.json)}
   ingest: ${self:custom.wranglers.ingest}
   enrichment: ${self:custom.wranglers.enrichment}
   imputation-movements: ${self:custom.wranglers.imputation-movements}

--- a/brk_serverless.yml
+++ b/brk_serverless.yml
@@ -652,3 +652,4 @@ stepFunctions:
 
 plugins:
   - serverless-step-functions
+  - serverless-pseudo-parameters

--- a/serverless.sh
+++ b/serverless.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 cd es-bmi-step-functions-deploy-repository
+serverless plugin install --name serverless-pseudo-parameters
 serverless plugin install --name serverless-step-functions
 echo Deploying Sand and Gravel to AWS...
 serverless deploy --config sg_serverless.yml --verbose;

--- a/sg_serverless.yml
+++ b/sg_serverless.yml
@@ -7,12 +7,12 @@ provider:
   package:
     individually: true
   deploymentBucket:
-    name: spp-results-sandbox-serverless
+    name: spp-results-${self:custom.environment}-serverless
 
 custom:
-  accountId: ${env:aws_account_id}
+  environment: ${env:ENVIRONMENT}
 
-  wranglers: ${file(../wranglers.json)}
+  wranglers: ${file(./wranglers.json)}
   ingest: ${self:custom.wranglers.ingest}
   enrichment: ${self:custom.wranglers.enrichment}
   strata: ${self:custom.wranglers.strata}
@@ -103,7 +103,7 @@ stepFunctions:
 
           Ingest:
             Next: Enrichment
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.ingest}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.ingest}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -124,7 +124,7 @@ stepFunctions:
 
           Enrichment:
             Next: Strata
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.enrichment}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.enrichment}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -149,7 +149,7 @@ stepFunctions:
 
           Strata:
             Next: Imputation Calculate Movements
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.strata}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.strata}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -173,7 +173,7 @@ stepFunctions:
 
           Imputation Calculate Movements:
             Next: Should Imputation Run
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-movements}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-movements}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -214,7 +214,7 @@ stepFunctions:
 
           Calculate All-GB Region:
             Next: Calculate Means
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.all-gb-region}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.all-gb-region}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -236,7 +236,7 @@ stepFunctions:
 
           Calculate Means:
             Next: Calculate IQRS
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-means}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-means}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -259,7 +259,7 @@ stepFunctions:
 
           Calculate IQRS:
             Next: Calculate Atypicals
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-iqrs}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-iqrs}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -282,7 +282,7 @@ stepFunctions:
 
           Calculate Atypicals:
             Next: Re-Calculate Means
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-atyps}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-atyps}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -303,7 +303,7 @@ stepFunctions:
 
           Re-Calculate Means:
             Next: Calculate Factors
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-recalc-means}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-recalc-means}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -326,7 +326,7 @@ stepFunctions:
 
           Calculate Factors:
             Next: Apply Factors
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-calc-factors}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-calc-factors}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -352,7 +352,7 @@ stepFunctions:
 
           Apply Factors:
             Next: Aggregation
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.imputation-apply-factors}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.imputation-apply-factors}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -416,7 +416,7 @@ stepFunctions:
                         run_id.$: $.run_id
                         total_columns.$: $.total_columns[1]
                         sns_topic_arn.$: $.sns_topic_arn
-                    Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
+                    Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
                     End: true
 
               - StartAt: EntRef Count
@@ -439,7 +439,7 @@ stepFunctions:
                         run_id.$: $.run_id
                         total_columns.$: $.total_columns[0]
                         sns_topic_arn.$: $.sns_topic_arn
-                    Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
+                    Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-column}"  # yamllint disable-line rule:line-length
                     End: true
 
               - StartAt: Calculate Top2
@@ -462,12 +462,12 @@ stepFunctions:
                         top2_column.$: $.top2_column
                         total_columns.$: $.total_columns[1]
                         sns_topic_arn.$: $.sns_topic_arn
-                    Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-top2}"  # yamllint disable-line rule:line-length
+                    Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-top2}"  # yamllint disable-line rule:line-length
                     End: true
 
           Combiner:
             Next: Disclosure
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.aggregation-combiner}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.aggregation-combiner}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -491,7 +491,7 @@ stepFunctions:
 
           Disclosure:
             Next: Success
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.disclosure-wrangler}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.disclosure-wrangler}"  # yamllint disable-line rule:line-length
             Catch:
               - ErrorEquals: [States.ALL]
                 ResultPath: $.error
@@ -524,17 +524,18 @@ stepFunctions:
 
           Success:
             End: true
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.method-return}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.method-return}"  # yamllint disable-line rule:line-length
             InputPath: $
             ResultPath: $.data.lambdaresult
             Type: Task
 
           Failure:
             End: true
-            Resource: "arn:aws:lambda:eu-west-2:${self:custom.accountId}:function:${self:custom.error-capture}"  # yamllint disable-line rule:line-length
+            Resource: "arn:aws:lambda:eu-west-2:#{AWS::AccountId}:function:${self:custom.error-capture}"  # yamllint disable-line rule:line-length
             InputPath: $
             ResultPath: $.data.lambdaresult
             Type: Task
 
 plugins:
   - serverless-step-functions
+  - serverless-pseudo-parameters

--- a/wranglers.json
+++ b/wranglers.json
@@ -1,0 +1,20 @@
+{
+  "ingest": "es-ingest-takeon-data-wrangler",
+  "enrichment": "es-enrichment-wrangler",
+  "strata": "es-strata-wrangler",
+  "imputation-movements": "es-imputation-calculate-movement-wrangler",
+  "imputation-means": "es-imputation-calculate-means-wrangler",
+  "imputation-iqrs": "es-imputation-iqrs-wrangler",
+  "imputation-atyps": "es-imputation-atypicals-wrangler",
+  "imputation-recalc-means": "es-imputation-recalculate-means-wrangler",
+  "imputation-calc-factors": "es-imputation-calculate-factors-wrangler",
+  "imputation-apply-factors": "es-imputation-apply-factors-wrangler",
+  "aggregation-top2": "es-aggregation-top2-wrangler",
+  "disclosure-wrangler": "es-disclosure-wrangler",
+  "error-capture": "runtime_error_capture",
+  "method-return": "es_statistical_method_return",
+  "all-gb-region": "es-add-regionless-wrangler",
+  "aggregation-bricks-splitter": "es-aggregation-bricks-splitter-wrangler",
+  "aggregation-column": "es-aggregation-column-wrangler",
+  "aggregation-combiner": "es-aggregation-combiner"
+}


### PR DESCRIPTION
This change is so that we dont pull variables out of secrets manager.
uses serverless-pseudo-parameters to get account id
AWS::Account id comes from the account being deployed to and populates when the deploy happens.

Environment and Environment type are passed in from environment variables in the pipeline.

Deployment bucket name now uses environment.(because sandbox bucket contains the word sandbox and integration bucket contains the word integration)

In step functions deploy, wranglers.json is now with the code.

All changes have been tested together in 'test-pipeline-without-secrets' in the new concourse.